### PR TITLE
Set DISALLOW_FILE_MODS To False For Staging

### DIFF
--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -4,4 +4,4 @@ ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
 /** Disable all file modifications including updates and update notifications */
-define('DISALLOW_FILE_MODS', true);
+define('DISALLOW_FILE_MODS', false);


### PR DESCRIPTION
Set DISALLOW_FILE_MODS to false for staging servers to allow for plugins
and themes to be installed from the WP console.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>